### PR TITLE
fix: do not stop on maps

### DIFF
--- a/internal/codegen/codegen.go
+++ b/internal/codegen/codegen.go
@@ -79,7 +79,7 @@ func IterateMessages(messages []*protogen.Message, fn func(message *protogen.Mes
 	for _, message := range messages {
 		if message.Desc.IsMapEntry() {
 			// Message is an auto generated message for map entries, skip it.
-			return nil
+			continue
 		}
 
 		if err := IterateMessages(message.Messages, fn); err != nil {


### PR DESCRIPTION
Do not stop processing sub messages when we encounter a map message.